### PR TITLE
Update --skip-test-unit option

### DIFF
--- a/.railsrc
+++ b/.railsrc
@@ -1,6 +1,6 @@
 --skip-bundle
 --skip-keeps
 --skip-spring
---skip-test-unit
+--skip-test
 --skip-turbolinks
 --database=postgresql


### PR DESCRIPTION
This option was renamed to `--skip-test` [back in Rails 5.0](https://github.com/rails/rails/blob/5-0-stable/railties/CHANGELOG.md).